### PR TITLE
build(deps): bump golang in /build/elasticsearch-indexer-rabbitmq

### DIFF
--- a/build/elasticsearch-indexer-rabbitmq/Dockerfile
+++ b/build/elasticsearch-indexer-rabbitmq/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.1-bookworm AS builder
+FROM golang:1.22.2-bookworm AS builder
 
 WORKDIR /build/
 


### PR DESCRIPTION
Bumps golang from 1.22.1-bookworm to 1.22.2-bookworm.

---
updated-dependencies:
- dependency-name: golang dependency-type: direct:production update-type: version-update:semver-patch ...